### PR TITLE
Fix UFO source validations after ufoLib validation on read changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 *,cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
       env: TOX_ENV=py35
     - python: 3.6
       env: TOX_ENV=py36
+    - python: 3.7
+      env: TOX_ENV=py37
 
 script: tox -e $TOX_ENV
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### v0.3.0
+
+- updated ufoLib dependency to v2.2.1
+- modified ufoLib.UFOReader instantiation in order to continue to support validation on UFO file reads after the ufoLib dependency changes
+- modified ufoLib.glifLib.GlyphSet instantiation in order to continue to support validation on UFO file reads after the ufoLib dependency changes
+- added Python 3.7 interpreter testing in CI testing settings files
+- eliminated Python 3.4 interpreter testing in CI testing settings files
+
 ### v0.2.2
 
 - updated ufoLib dependency to v2.1.1 (PR #6)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <img src ="https://raw.githubusercontent.com/source-foundry/ufolint/images/images/title-header-crunch.png" />
 
-[![Build Status](https://travis-ci.org/source-foundry/ufolint.svg?branch=master)](https://travis-ci.org/source-foundry/ufolint) [![Build status](https://ci.appveyor.com/api/projects/status/lsuj8p7myp6mdo2e/branch/master?svg=true)](https://ci.appveyor.com/project/chrissimpkins/ufolint/branch/master) [![codecov](https://codecov.io/gh/source-foundry/ufolint/branch/master/graph/badge.svg)](https://codecov.io/gh/source-foundry/ufolint)
+[![Build Status](https://semaphoreci.com/api/v1/sourcefoundry/ufolint/branches/master/shields_badge.svg)](https://semaphoreci.com/sourcefoundry/ufolint)
+[![Build status](https://ci.appveyor.com/api/projects/status/lsuj8p7myp6mdo2e/branch/master?svg=true)](https://ci.appveyor.com/project/chrissimpkins/ufolint/branch/master) 
+[![codecov](https://codecov.io/gh/source-foundry/ufolint/branch/master/graph/badge.svg)](https://codecov.io/gh/source-foundry/ufolint)
 
 
 ufolint is a source file linter for typeface development in [Unified Font Object](http://unifiedfontobject.org/) (UFO) source code.  It was designed for continuous integration testing of UFO source contributions to typeface projects. 

--- a/lib/ufolint/app.py
+++ b/lib/ufolint/app.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # ====================================================
-# Copyright 2017 Christopher Simpkins
+# Copyright 2018 Christopher Simpkins
 # MIT License
 # ====================================================
 

--- a/lib/ufolint/controllers/runner.py
+++ b/lib/ufolint/controllers/runner.py
@@ -183,7 +183,7 @@ class MainRunner(object):
             data_dir_path = os.path.join(self.ufopath, 'data')
 
             if dir_exists(data_dir_path):
-                ufo_reader = UFOReader(self.ufopath)
+                ufo_reader = UFOReader(self.ufopath, validate=True)
                 raw_data_list = ufo_reader.getDataDirectoryListing()
                 data_list = []
                 for item in raw_data_list:
@@ -277,7 +277,7 @@ class MainRunner(object):
         ss = StdStreamer(self.ufopath)
         res = Result(self.ufopath)
         try:
-            ufolib_reader = UFOReader(self.ufopath)
+            ufolib_reader = UFOReader(self.ufopath, validate=True)
             self.ufoversion = ufolib_reader.formatVersion
             self.ufolib_reader = ufolib_reader
             res.test_failed = False

--- a/lib/ufolint/settings.py
+++ b/lib/ufolint/settings.py
@@ -5,8 +5,8 @@
 # Version Number
 # ------------------------------------------------------------------------------
 major_version = "0"
-minor_version = "2"
-patch_version = "2"
+minor_version = "3"
+patch_version = "0"
 
 # ------------------------------------------------------------------------------
 # Help String
@@ -14,7 +14,7 @@ patch_version = "2"
 
 HELP = """====================================================
 ufolint
-Copyright 2017 Christopher Simpkins
+Copyright 2018 Christopher Simpkins
 MIT License
 Source: https://github.com/source-foundry/ufolint
 ====================================================

--- a/lib/ufolint/validators/glifvalidators.py
+++ b/lib/ufolint/validators/glifvalidators.py
@@ -28,7 +28,7 @@ def run_all_glif_validations(ufoobj):
         sys.stdout.flush()
         res = Result(glyphsdir)
         try:
-            gs = GlyphSet(glyphsdir, ufoFormatVersion=ufoversion)   # create a ufoLib GlyphSet
+            gs = GlyphSet(glyphsdir, ufoFormatVersion=ufoversion, validateRead=True)   # create a ufoLib GlyphSet
             # do not report success for this, previous testing has passed this
         except Exception as e:
             res.test_failed = True

--- a/lib/ufolint/validators/plistvalidators.py
+++ b/lib/ufolint/validators/plistvalidators.py
@@ -94,7 +94,7 @@ class MetainfoPlistValidator(AbstractPlistValidator):
             res.test_long_stdstream_string = "metainfo.plist is not available on the path " + self.testpath
             ss.stream_result(res)
         try:
-            ufolib_reader = UFOReader(self.ufopath)
+            ufolib_reader = UFOReader(self.ufopath, validate=True)
             ufolib_reader.readMetaInfo()
             res.test_failed = False
             ss.stream_result(res)
@@ -131,7 +131,7 @@ class FontinfoPlistValidator(AbstractPlistValidator):
             return self.test_fail_list
         try:
             # read fontinfo.plist with ufoLib - the ufoLib library performs type validations on values on read
-            ufolib_reader = UFOReader(self.ufopath)
+            ufolib_reader = UFOReader(self.ufopath, validate=True)
             ufolib_reader.readInfo(self.fontinfo_obj)
             res.test_failed = False
             ss.stream_result(res)
@@ -162,7 +162,7 @@ class GroupsPlistValidator(AbstractPlistValidator):
             return self.test_fail_list
         try:
             # read groups.plist with ufoLib - the ufoLib library performs type validations on values on read
-            ufolib_reader = UFOReader(self.ufopath)
+            ufolib_reader = UFOReader(self.ufopath, validate=True)
             ufolib_reader.readGroups()
             res.test_failed = False
             ss.stream_result(res)
@@ -193,7 +193,7 @@ class KerningPlistValidator(AbstractPlistValidator):
             return self.test_fail_list
         try:
             # read kerning.plist with ufoLib - the ufoLib library performs type validations on values on read
-            ufolib_reader = UFOReader(self.ufopath)
+            ufolib_reader = UFOReader(self.ufopath, validate=True)
             ufolib_reader.readKerning()
             res.test_failed = False
             ss.stream_result(res)
@@ -224,7 +224,7 @@ class LibPlistValidator(AbstractPlistValidator):
             return self.test_fail_list
         try:
             # read lib.plist with ufoLib - the ufoLib library performs type validations on values on read
-            ufolib_reader = UFOReader(self.ufopath)
+            ufolib_reader = UFOReader(self.ufopath, validate=True)
             ufolib_reader.readLib()
             res.test_failed = False
             ss.stream_result(res)
@@ -255,7 +255,7 @@ class ContentsPlistValidator(AbstractPlistValidator):
                 # read contents.plist with ufoLib as GlyphSet instantiation
                 # the ufoLib library performs type validations on values on read
                 # glyphs_dir_list is a list of lists mapped to glyphs dir name, glyphs dir path
-                gs = GlyphSet(rel_dir_path, ufoFormatVersion=self.ufoversion)  # test for raised exceptions
+                gs = GlyphSet(rel_dir_path, ufoFormatVersion=self.ufoversion, validateRead=True)  # test for raised exceptions
                 res.test_failed = False
                 ss.stream_result(res)
             except Exception as e:
@@ -286,7 +286,7 @@ class LayercontentsPlistValidator(AbstractPlistValidator):
             return self.test_fail_list
         try:
             # read layercontents.plist with ufoLib - the ufoLib library performs type validations on values on read
-            ufolib_reader = UFOReader(self.ufopath)
+            ufolib_reader = UFOReader(self.ufopath, validate=True)
             ufolib_reader.getLayerNames()
             res.test_failed = False
             ss.stream_result(res)
@@ -323,7 +323,7 @@ class LayerinfoPlistValidator(AbstractPlistValidator):
             rel_dir_path = os.path.join(self.ufopath, glyphs_dir[1])
 
             try:
-                gs = GlyphSet(rel_dir_path, ufoFormatVersion=self.ufoversion)
+                gs = GlyphSet(rel_dir_path, ufoFormatVersion=self.ufoversion, validateRead=True)
                 gs.readLayerInfo(self.layerinfo_obj)
                 res.test_failed = False
                 ss.stream_result(res)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ufoLib==2.1.1
+ufoLib==2.2.1
 commandlines
 fonttools

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -2,4 +2,4 @@
 
 # test_runner.sh : local testing script
 
-tox -e py27,py36
+tox -e py27,py37

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py35, py36, py37
 
 [testenv]
 passenv = TOXENV CI TRAVIS TRAVIS_*


### PR DESCRIPTION
As of ufoLib v2.2.0, the UFOReader class and GlyphSet class were modified to no longer validate UFO source files by default on reads.  This PR fixes ufolint validations based upon these dependency changes.