### PR TITLE
Explicitly depend on ufoLib >= 2.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     platforms=['any'],
     packages=find_packages("lib"),
     package_dir={'': 'lib'},
-    install_requires=['commandlines', 'ufoLib'],
+    install_requires=['commandlines', 'ufoLib>=2.2.0'],
     entry_points={
         'console_scripts': [
             'ufolint = ufolint.app:main'


### PR DESCRIPTION
The validators use the `validate` kwarg, which was introduced in 2.2.0.