### PR TITLE
Clearer glif error message

### DIFF
--- a/lib/ufolint/validators/glifvalidators.py
+++ b/lib/ufolint/validators/glifvalidators.py
@@ -48,7 +48,7 @@ def run_all_glif_validations(ufoobj):
                 glif_count += 1
             except Exception as e:
                 res.test_failed = True
-                res.test_long_stdstream_string = 'Test for glyph "{}" failed with error: {}'.format(glyphname, e)
+                res.test_long_stdstream_string = '{}, glyph "{}": Test failed with error: {}'.format(glyphsdir, glyphname, e)
                 ss.stream_result(res)
                 test_error_list.append(res)
                 glif_count += 1

--- a/lib/ufolint/validators/glifvalidators.py
+++ b/lib/ufolint/validators/glifvalidators.py
@@ -48,7 +48,7 @@ def run_all_glif_validations(ufoobj):
                 glif_count += 1
             except Exception as e:
                 res.test_failed = True
-                res.test_long_stdstream_string = glyphname + " test failed with error: " + str(e)
+                res.test_long_stdstream_string = 'Test for glyph "{}" failed with error: {}'.format(glyphname, e)
                 ss.stream_result(res)
                 test_error_list.append(res)
                 glif_count += 1

--- a/lib/ufolint/validators/glifvalidators.py
+++ b/lib/ufolint/validators/glifvalidators.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
 import sys
 
-from ufoLib.glifLib import GlyphSet
+from ufoLib.glifLib import GlyphSet, glyphNameToFileName
 
 from ufolint.data.tstobj import Result
 from ufolint.stdoutput import StdStreamer
@@ -48,7 +49,8 @@ def run_all_glif_validations(ufoobj):
                 glif_count += 1
             except Exception as e:
                 res.test_failed = True
-                res.test_long_stdstream_string = '{}, glyph "{}": Test failed with error: {}'.format(glyphsdir, glyphname, e)
+                filename = os.path.join(glyphsdir, glyphNameToFileName(glyphname, None))
+                res.test_long_stdstream_string = '{} (glyph "{}"): Test failed with error: {}'.format(filename, glyphname, e)
                 ss.stream_result(res)
                 test_error_list.append(res)
                 glif_count += 1


### PR DESCRIPTION
Previously, an error in glyph "a" or "A" could make for a confusing error message.

Fixes https://github.com/source-foundry/ufolint/issues/25.