### PR TITLE
Eliminate Py2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ target/
 # Project files
 tests/runner.py
 tests/profiler.py
+
+#pytype files
+.pytype

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,41 @@
-# Config file for automatic testing at travis-ci.org
-
-sudo: false
 language: python
 matrix:
   include:
-    - python: 2.7
-      env: TOX_ENV=py27
-    - python: 2.7
-      env: TOX_ENV=py34
+    - python: 3.7
+      dist: xenial
+      env: TOX_ENV=lint
+      install: pip install --upgrade flake8
+      script: make test-lint
+    - python: 3.7
+      dist: xenial
+      env: TOX_ENV=coverage
+      install:
+        - pip install --upgrade coverage pytest
+        - pip install .
+      script:
+        - coverage run --source ufolint -m py.test
+        - coverage report -m
+      after_success:
+        - bash <(curl -s https://codecov.io/bash)
     - python: 3.5
       env: TOX_ENV=py35
+      install: pip install --upgrade tox pytest
+      script: tox -e $TOX_ENV
     - python: 3.6
       env: TOX_ENV=py36
+      install: pip install --upgrade tox pytest
+      script: tox -e $TOX_ENV
     - python: 3.7
       env: TOX_ENV=py37
-
-script: tox -e $TOX_ENV
-
-install:
-    - pip install tox
+      install: pip install --upgrade tox pytest
+      dist: xenial
+      script: tox -e $TOX_ENV
+    - os: osx
+      language: generic
+      osx_image: xcode11    # Python 3.7.4 running on macOS 10.14.4
+      install: pip install --upgrade tox pytest
+      env: TOX_ENV=py37
+      script: tox -e $TOX_ENV
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ matrix:
         - coverage report -m
       after_success:
         - bash <(curl -s https://codecov.io/bash)
-    - python: 3.5
-      env: TOX_ENV=py35
-      install: pip install --upgrade tox pytest
-      script: tox -e $TOX_ENV
     - python: 3.6
       env: TOX_ENV=py36
       install: pip install --upgrade tox pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,16 @@ matrix:
       env: TOX_ENV=py37
       script: tox -e $TOX_ENV
 
+# The following prevents Travis from running CI on pull requests that come from a
+# branch in the same repository. Without this, it will run the same CI for the
+# pull request branch _and_ the pull request itself, which makes no sense.
+branches:
+  only:
+    - master
+    # We want to build wip/* branches since these are not usually used for PRs
+    - /^wip\/.*$/
+    # We want to build version tags as well.
+    - /^v\d+\.\d+.*$/
+
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - removed Py2 `plistlib.readPlist` in `ufolint.controllers.runner` module
 - removed Py2 `xml.etree.CElementTree` in `ufolint.validators.plistvalidators`
 - removed Py2 `xml.etree.CElementTree` in `ufolint.validators.xmlvalidators`
-- PEP8 formatting changes
+- PEP8 Python source formatting changes
 - add Makefile
 - remove unnecessary shell scripts (functionality replaced by Makefile)
 - update MANIFEST.in file paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Changelog
 
+### v0.4.0
+
+- converted from ufoLib to fontTools.ufoLib dependency
+- dropped support for Python 2.7
+- dropped support for Python 3 versions < 3.5
+- setup.py overhaul with new Python 3.5+ Python interpreter requirement
+- add fontTools [ufo] extras dependencies to requirements.txt
+- - switched `basestring` type to `str` type in `ufolint.validators.typevalidators` module
+- PEP8 formatting changes
+- add Makefile
+- remove unnecessary shell scripts (functionality replaced by Makefile)
+- update MANIFEST.in file paths
+- changed Python interpreter version in tox.ini configuration file
+
 ### v0.3.5
 
 - improved error messages on *.glif file test failures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - converted from ufoLib to fontTools.ufoLib dependency
 - dropped support for Python 2.7
-- dropped support for Python 3 versions < 3.5
-- setup.py overhaul with new Python 3.5+ Python interpreter requirement
+- dropped support for Python 3 versions < 3.6
+- setup.py overhaul with new Python 3.6+ Python interpreter requirement
 - add fontTools [ufo] extras dependencies to requirements.txt
 - - switched `basestring` type to `str` type in `ufolint.validators.typevalidators` module
 - PEP8 formatting changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### v0.4.0
 
 - converted from `ufoLib` to `fontTools.ufoLib` dependency
+- add requirement for `fontTools` library v4.0.0 (first Python 3.6+ only release)
 - dropped support for Python 2.7
 - dropped support for Python 3 versions < 3.6
 - setup.py overhaul with new Python 3.6+ Python interpreter requirement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ### v0.4.0
 
-- converted from ufoLib to fontTools.ufoLib dependency
+- converted from `ufoLib` to `fontTools.ufoLib` dependency
 - dropped support for Python 2.7
 - dropped support for Python 3 versions < 3.6
 - setup.py overhaul with new Python 3.6+ Python interpreter requirement
 - add fontTools [ufo] extras dependencies to requirements.txt
-- - switched `basestring` type to `str` type in `ufolint.validators.typevalidators` module
+- switched Py2 `basestring` type to `str` type in `ufolint.validators.typevalidators` module
+- removed Py2 `plistlib.readPlist` in `ufolint.controllers.runner` module
+- removed Py2 `xml.etree.CElementTree` in `ufolint.validators.plistvalidators`
+- removed Py2 `xml.etree.CElementTree` in `ufolint.validators.xmlvalidators`
 - PEP8 formatting changes
 - add Makefile
 - remove unnecessary shell scripts (functionality replaced by Makefile)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
 include docs/LICENSE
-include docs/README.rst
+include CHANGELOG.md
+include README.md
+
+include *requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+all: install
+
+black:
+	black lib/ufolint/*.py lib/ufolint/*/*.py
+
+clean:
+	- rm dist/*.whl dist/*.tar.gz dist/*.zip
+
+dist-build: clean
+	python3 setup.py sdist bdist_wheel
+
+dist-push:
+	twine upload dist/*.whl dist/*.tar.gz
+
+install:
+	pip3 install --ignore-installed -r requirements.txt .
+
+install-dev:
+	pip3 install --ignore-installed -r requirements.txt -e ".[dev]"
+
+install-user:
+	pip3 install --ignore-installed --user .
+
+test: test-lint test-unit
+
+test-coverage:
+	coverage run --source ufolint -m py.test
+	coverage report -m
+#	coverage html
+
+test-lint:
+	flake8 --ignore=E501,W50 lib/ufolint
+
+test-type-check:
+	pytype lib/ufolint
+
+test-unit:
+	tox
+
+uninstall:
+	pip3 uninstall --yes ufolint
+
+.PHONY: all black clean dist-build dist-push install install-dev install-user test test-lint test-type-check test-unit uninstall

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The application performs a UFO version specific static analysis of the source te
   - images follow UFO v3+ png specification
   - source files import into ufoLib library with ufoLib public methods
 
-These tests are performed through a combination of public methods in the [ufoLib library](https://github.com/unified-font-object/ufoLib) (released by the authors of the UFO specification) and additional tests that are implemented in the ufolint application.  ufolint catches exceptions raised in the ufoLib public read methods for all *.plist file types and all ufoLib validations performed on *.glif files.  These are returned to users with informative error messages that indicate the filepath(s) of concern and exit status code 1.
+These tests are performed through a combination of public methods in the [fontTools.ufoLib library](https://github.com/fonttools/fonttools/tree/master/Lib/fontTools/ufoLib) and additional tests that are implemented in the ufolint application.  ufolint catches exceptions raised in the ufoLib public read methods for all *.plist file types and all ufoLib validations performed on *.glif files.  These are returned to users with informative error messages that indicate the filepath(s) of concern and exit status code 1.
 
 
 # Install and Upgrade
@@ -127,7 +127,7 @@ This Travis setting structure performs the variant tests in parallel for each of
 
 ## Acknowledgments
 
-Built with the fantastic [ufoLib library](https://github.com/unified-font-object/ufoLib) where a majority of the UFO validation work has been performed!
+Built with the fantastic [fontTools ufoLib library](https://github.com/fonttools/fonttools) where a majority of the UFO validation work has been performed!
 
 
 ## License

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,20 +1,32 @@
-build: false
 environment:
   matrix:
-    - TOXENV: py27
-    - TOXENV: py34
-    - TOXENV: py35
-    - TOXENV: py36
-platform:
-  - x86
-  - x64
-init:
-  - "ECHO %TOXENV%"
-  - ps: "ls C:\\Python*"
+    - JOB: "3.5 64-bit"
+      PYTHON_HOME: "C:\\Python35-x64"
+      TOX_PY: py35
+
+    - JOB: "3.6 32-bit"
+      PYTHON_HOME: "C:\\Python36"
+      TOX_PY: py36
+
+    - JOB: "3.7 64-bit"
+      PYTHON_HOME: "C:\\Python37-x64"
+      TOX_PY: py37
+
 install:
-  - "c:\\python27\\Scripts\\pip install tox"
+  # Prepend Python to the PATH of this build
+  - "SET PATH=%PYTHON_HOME%;%PYTHON_HOME%\\Scripts;%PATH%"
+
+  # check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # upgrade pip and setuptools to avoid out-of-date warnings
+  - "python -m pip install --disable-pip-version-check --user --upgrade pip setuptools virtualenv"
+
+  # install the dependencies to run the tests
+  - "python -m pip install tox"
+
+build: false
+
 test_script:
-  - "git clean -f -d -x"
-  - "c:\\python27\\Scripts\\tox --version"
-  - "c:\\python27\\Scripts\\pip --version"
-  - "c:\\python27\\Scripts\\tox"
+  - "tox -e %TOX_PY%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,5 @@
 environment:
   matrix:
-    - JOB: "3.5 64-bit"
-      PYTHON_HOME: "C:\\Python35-x64"
-      TOX_PY: py35
-
     - JOB: "3.6 32-bit"
       PYTHON_HOME: "C:\\Python36"
       TOX_PY: py36

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-coverage run --source ufolint -m py.test
-coverage report -m
-coverage html
-
-coverage xml
-codecov --token=$CODECOV_UFOLINT

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,7 +1,0 @@
-ufolint
-=======
-
-A Unified Font Object (UFO) source file linter for typeface development.  ufolint was developed to support continuous integration testing of source contributions to typeface projects that use UFO source code.
-
-Documentation and issue reporting are available on the `GitHub repository <https://github.com/source-foundry/ufolint>`_ .
-

--- a/lib/ufolint/__init__.py
+++ b/lib/ufolint/__init__.py
@@ -1,3 +1,2 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-

--- a/lib/ufolint/app.py
+++ b/lib/ufolint/app.py
@@ -19,7 +19,10 @@ def main():
     c = Command()
 
     if c.does_not_validate_missing_args():
-        sys.stderr.write("[ufolint] ERROR: Please include one or more UFO directory arguments with your command." + os.linesep)
+        sys.stderr.write(
+            "[ufolint] ERROR: Please include one or more UFO directory arguments with your command."
+            + os.linesep
+        )
         sys.exit(1)
 
     if c.is_help_request():
@@ -37,4 +40,6 @@ def main():
             hh = MainRunner(argument)
             hh.run()
 
-    sys.exit(0)  # if the script completes without status code 1 SystemExit being raised, then all tests passed
+    sys.exit(
+        0
+    )  # if the script completes without status code 1 SystemExit being raised, then all tests passed

--- a/lib/ufolint/app.py
+++ b/lib/ufolint/app.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # ====================================================
-# Copyright 2018 Christopher Simpkins
+# Copyright 2018 Source Foundry Authors
 # MIT License
 # ====================================================
 

--- a/lib/ufolint/controllers/__init__.py
+++ b/lib/ufolint/controllers/__init__.py
@@ -1,3 +1,2 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-

--- a/lib/ufolint/controllers/runner.py
+++ b/lib/ufolint/controllers/runner.py
@@ -13,9 +13,20 @@ from ufolint.stdoutput import StdStreamer
 from ufolint.utilities import file_exists, dir_exists
 from ufolint.validators.glifvalidators import run_all_glif_validations
 from ufolint.validators.imagesvalidators import run_all_images_validations
-from ufolint.validators.plistvalidators import MetainfoPlistValidator, FontinfoPlistValidator, GroupsPlistValidator
-from ufolint.validators.plistvalidators import KerningPlistValidator, LibPlistValidator, ContentsPlistValidator
-from ufolint.validators.plistvalidators import LayercontentsPlistValidator, LayerinfoPlistValidator
+from ufolint.validators.plistvalidators import (
+    MetainfoPlistValidator,
+    FontinfoPlistValidator,
+    GroupsPlistValidator,
+)
+from ufolint.validators.plistvalidators import (
+    KerningPlistValidator,
+    LibPlistValidator,
+    ContentsPlistValidator,
+)
+from ufolint.validators.plistvalidators import (
+    LayercontentsPlistValidator,
+    LayerinfoPlistValidator,
+)
 
 
 class MainRunner(object):
@@ -23,17 +34,21 @@ class MainRunner(object):
         self.ufopath = ufopath
         self.ufolib_reader = None
         self.ufoversion = None
-        self.failures_list = []        # list of strings that include all failures across all tests for final report
-        self.ufo_glyphs_dir_list = []  # list of glyphs directory(ies) available in the source (>1 permitted in UFOv3+)
+        self.failures_list = (
+            []
+        )  # list of strings that include all failures across all tests for final report
+        self.ufo_glyphs_dir_list = (
+            []
+        )  # list of glyphs directory(ies) available in the source (>1 permitted in UFOv3+)
         self.ufoobj = None
 
     def run(self):
         # Print UFO filepath header
         print(" ")
         print("ufolint:")
-        print('~' * len(self.ufopath))
+        print("~" * len(self.ufopath))
         print(self.ufopath)
-        print('~' * len(self.ufopath))
+        print("~" * len(self.ufopath))
         print(" ")
 
         # [START] EARLY FAIL TESTS ----------------------------------------------------------------
@@ -46,33 +61,49 @@ class MainRunner(object):
         #        v2 only: no layercontents.plist, define as single glyphs directory
         ss = StdStreamer(self.ufopath)
         ss.stream_testname("UFO directory")
-        self._check_ufo_dir_path_exists()                 # tests user defined UFO directory path
-        self._check_ufo_dir_extension()                   # tests for .ufo extension on directory
-        self._check_metainfo_plist_exists()              # confirm presence of metainfo.plist to define UFO version
-        self._validate_read_data_types_metainfo_plist()   # validate the version data type as integer (workaround for bug in ufoLib)
-        self._check_ufo_import_and_define_ufo_version()   # confirm ufoLib can import directory. defines UFOReader object as class property
+        self._check_ufo_dir_path_exists()  # tests user defined UFO directory path
+        self._check_ufo_dir_extension()  # tests for .ufo extension on directory
+        self._check_metainfo_plist_exists()  # confirm presence of metainfo.plist to define UFO version
+        self._validate_read_data_types_metainfo_plist()  # validate the version data type as integer (workaround for bug in ufoLib)
+        self._check_ufo_import_and_define_ufo_version()  # confirm ufoLib can import directory. defines UFOReader object as class property
         if self.ufoversion == 3:
-            self._check_layercontents_plist_exists()                  # tests for presence of a layercontents.plist in root of UFO
+            self._check_layercontents_plist_exists()  # tests for presence of a layercontents.plist in root of UFO
             self._validate_read_load_glyphsdirs_layercontents_plist()  # validate layercontents.plist xml and load glyphs dirs
         elif self.ufoversion == 2:
-            self.ufo_glyphs_dir_list = [['public.default', 'glyphs']]  # define as single glyphs directory for UFOv2
-        else:   # pragma nocoverage fail if unsupported UFO version (ufolint fail in case behind released UFO version)
-            sys.stderr.write(os.linesep + "[ufolint] UFO v" + self.ufoversion + " is not supported in ufolint" + os.linesep)
+            self.ufo_glyphs_dir_list = [
+                ["public.default", "glyphs"]
+            ]  # define as single glyphs directory for UFOv2
+        else:  # pragma nocoverage fail if unsupported UFO version (ufolint fail in case behind released UFO version)
+            sys.stderr.write(
+                os.linesep
+                + "[ufolint] UFO v"
+                + self.ufoversion
+                + " is not supported in ufolint"
+                + os.linesep
+            )
             sys.exit(1)
         print(" ")
         print("   Found UFO v" + str(self.ufoversion))
         print("   Detected glyphs directories: ")
         for glyphs_dir in self.ufo_glyphs_dir_list:
             # TODO: add glyphs directory validation here : confirm naming = 'glyphs.*'
-            sys.stdout.write("     -- " + glyphs_dir[1] + " ")       # display the name of the specified glyphs dirs
+            sys.stdout.write(
+                "     -- " + glyphs_dir[1] + " "
+            )  # display the name of the specified glyphs dirs
             res = Result(glyphs_dir[1])
-            if dir_exists(os.path.join(self.ufopath, glyphs_dir[1])):  # test for presence of specified glyphs dir
+            if dir_exists(
+                os.path.join(self.ufopath, glyphs_dir[1])
+            ):  # test for presence of specified glyphs dir
                 res.test_failed = False
                 ss.stream_result(res)
             else:
                 res.test_failed = True
                 res.exit_failure = True
-                res.test_long_stdstream_string = "Unable to find the UFO directory '" + glyphs_dir[1] + "' defined in layercontents.plist"
+                res.test_long_stdstream_string = (
+                    "Unable to find the UFO directory '"
+                    + glyphs_dir[1]
+                    + "' defined in layercontents.plist"
+                )
                 ss.stream_result(res)
             print(" ")
 
@@ -94,7 +125,9 @@ class MainRunner(object):
             else:
                 res.test_failed = True
                 res.exit_failure = True
-                res.test_long_stdstream_string = mandatory_file + " was not found in " + self.ufopath
+                res.test_long_stdstream_string = (
+                    mandatory_file + " was not found in " + self.ufopath
+                )
                 ss.stream_result(res)
         print(" ")
         # [END] Mandatory file path tests
@@ -102,14 +135,30 @@ class MainRunner(object):
 
         # [START] XML VALIDATION TESTS  -----------------------------------------------------------
         ss.stream_testname("XML formatting")
-        meta_val = MetainfoPlistValidator(self.ufopath, self.ufoversion, self.ufo_glyphs_dir_list)
-        fontinfo_val = FontinfoPlistValidator(self.ufopath, self.ufoversion, self.ufo_glyphs_dir_list)
-        groups_val = GroupsPlistValidator(self.ufopath, self.ufoversion, self.ufo_glyphs_dir_list)
-        kerning_val = KerningPlistValidator(self.ufopath, self.ufoversion, self.ufo_glyphs_dir_list)
-        lib_val = LibPlistValidator(self.ufopath, self.ufoversion, self.ufo_glyphs_dir_list)
-        contents_val = ContentsPlistValidator(self.ufopath, self.ufoversion, self.ufo_glyphs_dir_list)
-        layercont_val = LayercontentsPlistValidator(self.ufopath, self.ufoversion, self.ufo_glyphs_dir_list)
-        layerinfo_val = LayerinfoPlistValidator(self.ufopath, self.ufoversion, self.ufo_glyphs_dir_list)
+        meta_val = MetainfoPlistValidator(
+            self.ufopath, self.ufoversion, self.ufo_glyphs_dir_list
+        )
+        fontinfo_val = FontinfoPlistValidator(
+            self.ufopath, self.ufoversion, self.ufo_glyphs_dir_list
+        )
+        groups_val = GroupsPlistValidator(
+            self.ufopath, self.ufoversion, self.ufo_glyphs_dir_list
+        )
+        kerning_val = KerningPlistValidator(
+            self.ufopath, self.ufoversion, self.ufo_glyphs_dir_list
+        )
+        lib_val = LibPlistValidator(
+            self.ufopath, self.ufoversion, self.ufo_glyphs_dir_list
+        )
+        contents_val = ContentsPlistValidator(
+            self.ufopath, self.ufoversion, self.ufo_glyphs_dir_list
+        )
+        layercont_val = LayercontentsPlistValidator(
+            self.ufopath, self.ufoversion, self.ufo_glyphs_dir_list
+        )
+        layerinfo_val = LayerinfoPlistValidator(
+            self.ufopath, self.ufoversion, self.ufo_glyphs_dir_list
+        )
 
         # excute validations, returns list of failure Result() objects
         mv_xml_fail_list = meta_val.run_xml_validation()
@@ -122,14 +171,16 @@ class MainRunner(object):
         li_xml_fail_list = layerinfo_val.run_xml_validation()
 
         # xml validations return lists of all failures, append these to the class failures_list Python list
-        for thelist in (mv_xml_fail_list,
-                        fi_xml_fail_list,
-                        g_xml_fail_list,
-                        k_xml_fail_list,
-                        l_xml_fail_list,
-                        c_xml_fail_list,
-                        lc_xml_fail_list,
-                        li_xml_fail_list):
+        for thelist in (
+            mv_xml_fail_list,
+            fi_xml_fail_list,
+            g_xml_fail_list,
+            k_xml_fail_list,
+            l_xml_fail_list,
+            c_xml_fail_list,
+            lc_xml_fail_list,
+            li_xml_fail_list,
+        ):
             for failed_test_result in thelist:
                 self.failures_list.append(failed_test_result)
         print(" ")
@@ -146,14 +197,16 @@ class MainRunner(object):
         lc_ufolib_import_fail_list = layercont_val.run_ufolib_import_validation()
         li_ufolib_import_fail_list = layerinfo_val.run_ufolib_import_validation()
 
-        for thelist in (mv_ufolib_import_fail_list,
-                        fi_ufolib_import_fail_list,
-                        g_ufolib_import_fail_list,
-                        k_ufolib_import_fail_list,
-                        l_ufolib_import_fail_list,
-                        c_ufolib_import_fail_list,
-                        lc_ufolib_import_fail_list,
-                        li_ufolib_import_fail_list):
+        for thelist in (
+            mv_ufolib_import_fail_list,
+            fi_ufolib_import_fail_list,
+            g_ufolib_import_fail_list,
+            k_ufolib_import_fail_list,
+            l_ufolib_import_fail_list,
+            c_ufolib_import_fail_list,
+            lc_ufolib_import_fail_list,
+            li_ufolib_import_fail_list,
+        ):
             for failed_test_result in thelist:
                 self.failures_list.append(failed_test_result)
 
@@ -162,7 +215,7 @@ class MainRunner(object):
         # [START] features.fea TESTS
         print(" ")
         ss.stream_testname("features.fea")
-        ff_path = os.path.join(self.ufopath, 'features.fea')
+        ff_path = os.path.join(self.ufopath, "features.fea")
         res = Result(ff_path)
         if file_exists(ff_path):
             res.test_failed = False
@@ -175,35 +228,41 @@ class MainRunner(object):
         if self.ufoversion == 3:  # UFOv3+ only
             print(" ")
             ss.stream_testname("data")
-            data_dir_path = os.path.join(self.ufopath, 'data')
+            data_dir_path = os.path.join(self.ufopath, "data")
 
             if dir_exists(data_dir_path):
                 ufo_reader = UFOReader(self.ufopath, validate=True)
                 raw_data_list = ufo_reader.getDataDirectoryListing()
                 data_list = []
                 for item in raw_data_list:
-                    if not item[0] == ".":   # eliminate dotfiles picked up by the ufoLib method (e.g. .DS_Store on OSX)
+                    if (
+                        not item[0] == "."
+                    ):  # eliminate dotfiles picked up by the ufoLib method (e.g. .DS_Store on OSX)
                         data_list.append(item)
                 if len(data_list) == 0:
                     sys.stdout.write("empty")
                 else:
                     sys.stdout.write(str(len(data_list)) + " data files")
             else:
-                sys.stdout.write("not present")   # not a mandatory directory, not a failure
+                sys.stdout.write(
+                    "not present"
+                )  # not a mandatory directory, not a failure
         # [END] DATA DIRECTORY TESTS
 
         # [START] IMAGES DIRECTORY TESTS
-        if self.ufoversion == 3:   # UFO v3+ only
+        if self.ufoversion == 3:  # UFO v3+ only
             print(" ")
             ss.stream_testname("images")
-            images_dir_path = os.path.join(self.ufopath, 'images')
+            images_dir_path = os.path.join(self.ufopath, "images")
 
             if dir_exists(images_dir_path):
                 images_dir_failures = run_all_images_validations(self.ufoobj)
                 for images_failure_result in images_dir_failures:
                     self.failures_list.append(images_failure_result)
             else:
-                sys.stdout.write("not present")  # not a mandatory directory, not a failure
+                sys.stdout.write(
+                    "not present"
+                )  # not a mandatory directory, not a failure
         # [END] IMAGES DIRECTORY TESTS
 
         # [START] *.glif VALIDATION TESTS
@@ -232,7 +291,7 @@ class MainRunner(object):
         :return: None - method leads to early exit with status code 1 if file not found
         """
         ss = StdStreamer(self.ufopath)
-        lcp_test_filepath = os.path.join(self.ufopath, 'layercontents.plist')
+        lcp_test_filepath = os.path.join(self.ufopath, "layercontents.plist")
         res = Result(lcp_test_filepath)
 
         if file_exists(lcp_test_filepath):
@@ -240,8 +299,12 @@ class MainRunner(object):
             ss.stream_result(res)
         else:
             res.test_failed = True
-            res.exit_failure = True  # early exit if cannot find this file to define glyphs directories in UFO source
-            res.test_long_stdstream_string = "layercontents.plist was not found in " + self.ufopath
+            res.exit_failure = (
+                True
+            )  # early exit if cannot find this file to define glyphs directories in UFO source
+            res.test_long_stdstream_string = (
+                "layercontents.plist was not found in " + self.ufopath
+            )
             ss.stream_result(res)
 
     def _check_metainfo_plist_exists(self):
@@ -250,7 +313,7 @@ class MainRunner(object):
         :return: None = method leads to early exit with status code 1 if file not found
         """
         ss = StdStreamer(self.ufopath)
-        meta_test_filepath = os.path.join(self.ufopath, 'metainfo.plist')
+        meta_test_filepath = os.path.join(self.ufopath, "metainfo.plist")
         res = Result(meta_test_filepath)
 
         if file_exists(meta_test_filepath):
@@ -258,8 +321,12 @@ class MainRunner(object):
             ss.stream_result(res)
         else:
             res.test_failed = True
-            res.exit_failure = True  # early exit if cannot find this file to define glyphs directories in UFO source
-            res.test_long_stdstream_string = "metainfo.plist was not found in " + self.ufopath
+            res.exit_failure = (
+                True
+            )  # early exit if cannot find this file to define glyphs directories in UFO source
+            res.test_long_stdstream_string = (
+                "metainfo.plist was not found in " + self.ufopath
+            )
             ss.stream_result(res)
 
     def _check_ufo_import_and_define_ufo_version(self):
@@ -280,7 +347,12 @@ class MainRunner(object):
         except Exception as e:
             res.test_failed = True
             res.exit_failure = True
-            res.test_long_stdstream_string = "ufoLib raised an exception with import of " + self.ufopath + os.linesep + str(e)
+            res.test_long_stdstream_string = (
+                "ufoLib raised an exception with import of "
+                + self.ufopath
+                + os.linesep
+                + str(e)
+            )
             self.failures_list.append(res)
             ss.stream_result(res)
 
@@ -299,7 +371,9 @@ class MainRunner(object):
         else:
             res.test_failed = True
             res.exit_failure = True
-            res.test_long_stdstream_string = self.ufopath + " directory does not have a .ufo extension"
+            res.test_long_stdstream_string = (
+                self.ufopath + " directory does not have a .ufo extension"
+            )
             self.failures_list.append(res)
             ss.stream_result(res)
 
@@ -320,41 +394,51 @@ class MainRunner(object):
             res = Result(self.ufopath)
             res.test_failed = True
             res.exit_failure = True
-            res.test_long_stdstream_string = self.ufopath + " does not appear to be a valid UFO directory"
+            res.test_long_stdstream_string = (
+                self.ufopath + " does not appear to be a valid UFO directory"
+            )
             self.failures_list.append(res.test_long_stdstream_string)
             ss.stream_result(res)  # raises sys.exit(1) on this failure
 
     def _validate_read_data_types_metainfo_plist(self):
-        metainfo_plist_path = os.path.join(self.ufopath, 'metainfo.plist')
+        metainfo_plist_path = os.path.join(self.ufopath, "metainfo.plist")
         res = Result(metainfo_plist_path)
         ss = StdStreamer(metainfo_plist_path)
         try:
             with open(metainfo_plist_path, "rb") as f:
                 meta_dict = load(f)
-                if 'formatVersion' in meta_dict.keys():
-                    if isinstance(meta_dict['formatVersion'], int):
+                if "formatVersion" in meta_dict.keys():
+                    if isinstance(meta_dict["formatVersion"], int):
                         res.test_failed = False
                         ss.stream_result(res)
                     else:
                         res.test_failed = True
                         res.exit_failure = True  # early exit if fails
-                        res.test_long_stdstream_string = metainfo_plist_path + " 'formatVersion' value must be specified as" \
-                                                                               " an integer"
+                        res.test_long_stdstream_string = (
+                            metainfo_plist_path
+                            + " 'formatVersion' value must be specified as"
+                            " an integer"
+                        )
                         ss.stream_result(res)
                 else:
                     res.test_failed = True
                     res.exit_failure = True  # early exit if fails
-                    res.test_long_stdstream_string = "Failed to read the 'formatVersion' value in " + metainfo_plist_path
+                    res.test_long_stdstream_string = (
+                        "Failed to read the 'formatVersion' value in "
+                        + metainfo_plist_path
+                    )
                     ss.stream_result(res)
         except Exception as e:
             res.test_failed = True
             res.exit_failure = True  # early exit if fails
-            res.test_long_stdstream_string = "Failed to read the 'formatVersion' value in " \
-                                             "the file " + metainfo_plist_path + ". Error: " + str(e)
+            res.test_long_stdstream_string = (
+                "Failed to read the 'formatVersion' value in "
+                "the file " + metainfo_plist_path + ". Error: " + str(e)
+            )
             ss.stream_result(res)
 
     def _validate_read_load_glyphsdirs_layercontents_plist(self):
-        layercontents_plist_path = os.path.join(self.ufopath, 'layercontents.plist')
+        layercontents_plist_path = os.path.join(self.ufopath, "layercontents.plist")
         res = Result(layercontents_plist_path)
         ss = StdStreamer(layercontents_plist_path)
         try:
@@ -366,5 +450,7 @@ class MainRunner(object):
         except Exception as e:
             res.test_failed = True
             res.exit_failure = True
-            res.test_long_stdstream_string = "Failed to read " + layercontents_plist_path + ". Error: " + str(e)
+            res.test_long_stdstream_string = (
+                "Failed to read " + layercontents_plist_path + ". Error: " + str(e)
+            )
             ss.stream_result(res)

--- a/lib/ufolint/controllers/runner.py
+++ b/lib/ufolint/controllers/runner.py
@@ -3,10 +3,7 @@
 
 import os
 import sys
-try:  # pragma nocoverage
-    from plistlib import readPlist as load
-except ImportError:  # pragma nocoverage
-    from plistlib import load
+from plistlib import load
 
 from fontTools.ufoLib import UFOReader
 
@@ -332,22 +329,23 @@ class MainRunner(object):
         res = Result(metainfo_plist_path)
         ss = StdStreamer(metainfo_plist_path)
         try:
-            meta_dict = load(metainfo_plist_path)
-            if 'formatVersion' in meta_dict.keys():
-                if isinstance(meta_dict['formatVersion'], int):
-                    res.test_failed = False
-                    ss.stream_result(res)
+            with open(metainfo_plist_path, "rb") as f:
+                meta_dict = load(f)
+                if 'formatVersion' in meta_dict.keys():
+                    if isinstance(meta_dict['formatVersion'], int):
+                        res.test_failed = False
+                        ss.stream_result(res)
+                    else:
+                        res.test_failed = True
+                        res.exit_failure = True  # early exit if fails
+                        res.test_long_stdstream_string = metainfo_plist_path + " 'formatVersion' value must be specified as" \
+                                                                               " an integer"
+                        ss.stream_result(res)
                 else:
                     res.test_failed = True
                     res.exit_failure = True  # early exit if fails
-                    res.test_long_stdstream_string = metainfo_plist_path + " 'formatVersion' value must be specified as" \
-                                                                           " an integer"
+                    res.test_long_stdstream_string = "Failed to read the 'formatVersion' value in " + metainfo_plist_path
                     ss.stream_result(res)
-            else:
-                res.test_failed = True
-                res.exit_failure = True  # early exit if fails
-                res.test_long_stdstream_string = "Failed to read the 'formatVersion' value in " + metainfo_plist_path
-                ss.stream_result(res)
         except Exception as e:
             res.test_failed = True
             res.exit_failure = True  # early exit if fails
@@ -361,9 +359,10 @@ class MainRunner(object):
         ss = StdStreamer(layercontents_plist_path)
         try:
             # loads as [ ['layername1', 'glyphsdir1'], ['layername2', 'glyphsdir2'] ]
-            self.ufo_glyphs_dir_list = load(layercontents_plist_path)
-            res.test_failed = False
-            ss.stream_result(res)
+            with open(layercontents_plist_path, "rb") as f:
+                self.ufo_glyphs_dir_list = load(f)
+                res.test_failed = False
+                ss.stream_result(res)
         except Exception as e:
             res.test_failed = True
             res.exit_failure = True

--- a/lib/ufolint/data/__init__.py
+++ b/lib/ufolint/data/__init__.py
@@ -1,3 +1,2 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-

--- a/lib/ufolint/data/tstobj.py
+++ b/lib/ufolint/data/tstobj.py
@@ -6,8 +6,15 @@ class Result(object):
     """
     Data object that maintains test result success status and test result message (intended for std output to user)
     """
+
     def __init__(self, filepath):
         self.test_filepath = filepath
-        self.test_failed = None               # test result indicator, True = test failed, False = test succeeded
-        self.exit_failure = None              # when set to True, sys.exit(1) raised immediately on this error result
-        self.test_long_stdstream_string = ""  # maintains std output string to be presented to user for each test result
+        self.test_failed = (
+            None
+        )  # test result indicator, True = test failed, False = test succeeded
+        self.exit_failure = (
+            None
+        )  # when set to True, sys.exit(1) raised immediately on this error result
+        self.test_long_stdstream_string = (
+            ""
+        )  # maintains std output string to be presented to user for each test result

--- a/lib/ufolint/data/ufo.py
+++ b/lib/ufolint/data/ufo.py
@@ -7,7 +7,9 @@ import os.path
 class Ufo(object):
     def __init__(self, ufopath, glyphsdir_list):
         self.ufopath = ufopath
-        self.ufoversion = None  # defined on instantiation in the classes that inherit Ufo
+        self.ufoversion = (
+            None
+        )  # defined on instantiation in the classes that inherit Ufo
         self.glyphsdir_list = glyphsdir_list
         self.mandatory_root_basefilepaths = None
         self.mandatory_glyphsdir_basefilepaths = None
@@ -41,7 +43,9 @@ class Ufo(object):
         path_list = []
         for glyphsdir in self.glyphsdir_list:
             glyphsdir_basename = glyphsdir[1]
-            path_list.append(self._make_glyphsdir_plist_path(glyphsdir_basename, basefilename))
+            path_list.append(
+                self._make_glyphsdir_plist_path(glyphsdir_basename, basefilename)
+            )
         return path_list
 
     def get_mandatory_filepaths_list(self):
@@ -52,9 +56,13 @@ class Ufo(object):
         """
         mandatory_filepath_list = []
         for mandatory_root_basefile in self.mandatory_root_basefilepaths:
-            mandatory_filepath_list.append(self.get_root_plist_filepath(mandatory_root_basefile))
+            mandatory_filepath_list.append(
+                self.get_root_plist_filepath(mandatory_root_basefile)
+            )
         for mandatory_glyphs_basefile in self.mandatory_glyphsdir_basefilepaths:
-            glyphsdirs_filelist = self.get_glyphsdir_plist_filepath_list(mandatory_glyphs_basefile)
+            glyphsdirs_filelist = self.get_glyphsdir_plist_filepath_list(
+                mandatory_glyphs_basefile
+            )
             for a_file in glyphsdirs_filelist:
                 mandatory_filepath_list.append(a_file)
         return mandatory_filepath_list
@@ -72,21 +80,21 @@ class Ufo2(Ufo):
         self.ufopath = ufopath
         self.ufoversion = 2
         self.glyphsdir_list = glyphsdir_list
-        self.mandatory_root_basefilepaths = ['metainfo.plist']
-        self.mandatory_glyphsdir_basefilepaths = ['contents.plist']
+        self.mandatory_root_basefilepaths = ["metainfo.plist"]
+        self.mandatory_glyphsdir_basefilepaths = ["contents.plist"]
         self.all_root_plist_files_list = [
-            'metainfo.plist',
-            'fontinfo.plist',
-            'groups.plist',
-            'kerning.plist',
-            'lib.plist'
+            "metainfo.plist",
+            "fontinfo.plist",
+            "groups.plist",
+            "kerning.plist",
+            "lib.plist",
         ]
-        self.all_glyphsdir_plist_files_list = [
-            'contents.plist'
-        ]
+        self.all_glyphsdir_plist_files_list = ["contents.plist"]
 
     def get_glyphsdir_path_list(self):
-        glyphsdir_path = os.path.join(self.ufopath, 'glyphs')     # UFOv2 includes only one glyphs directory
+        glyphsdir_path = os.path.join(
+            self.ufopath, "glyphs"
+        )  # UFOv2 includes only one glyphs directory
         return [glyphsdir_path]
 
 
@@ -96,23 +104,17 @@ class Ufo3(Ufo):
         self.ufopath = ufopath
         self.ufoversion = 3
         self.glyphsdir_list = glyphsdir_list
-        self.mandatory_root_basefilepaths = [
-            'metainfo.plist',
-            'layercontents.plist'
-        ]
-        self.mandatory_glyphsdir_basefilepaths = ['contents.plist']
+        self.mandatory_root_basefilepaths = ["metainfo.plist", "layercontents.plist"]
+        self.mandatory_glyphsdir_basefilepaths = ["contents.plist"]
         self.all_root_plist_files_list = [
-            'metainfo.plist',
-            'fontinfo.plist',
-            'groups.plist',
-            'kerning.plist',
-            'lib.plist',
-            'layercontents.plist'
+            "metainfo.plist",
+            "fontinfo.plist",
+            "groups.plist",
+            "kerning.plist",
+            "lib.plist",
+            "layercontents.plist",
         ]
-        self.all_glyphsdir_plist_files_list = [
-            'contents.plist',
-            'layerinfo.plist'
-        ]
+        self.all_glyphsdir_plist_files_list = ["contents.plist", "layerinfo.plist"]
 
     def get_glyphsdir_path_list(self):
         glyphsdir_path_list = []

--- a/lib/ufolint/settings.py
+++ b/lib/ufolint/settings.py
@@ -5,8 +5,8 @@
 # Version Number
 # ------------------------------------------------------------------------------
 major_version = "0"
-minor_version = "3"
-patch_version = "5"
+minor_version = "4"
+patch_version = "0"
 
 # ------------------------------------------------------------------------------
 # Help String
@@ -14,7 +14,7 @@ patch_version = "5"
 
 HELP = """====================================================
 ufolint
-Copyright 2018 Source Foundry Authors
+Copyright 2019 Source Foundry Authors
 MIT License
 Source: https://github.com/source-foundry/ufolint
 ====================================================

--- a/lib/ufolint/stdoutput/__init__.py
+++ b/lib/ufolint/stdoutput/__init__.py
@@ -29,14 +29,20 @@ class StdStreamer(object):
         if resultobj.test_failed is True:
             self._stream_short(self.short_fail_string)
             if resultobj.exit_failure is True:
-                fail_string = self.ufopath + " failed ufolint testing! Exit with status code 1"
+                fail_string = (
+                    self.ufopath + " failed ufolint testing! Exit with status code 1"
+                )
                 print(os.linesep)
                 print("=" * len(fail_string))
                 print(self.ufopath + " failed ufolint testing! Exit with status code 1")
                 print("=" * len(fail_string))
                 print(" ")
                 print("Test result that led to failure:")
-                print(self.fail_long_indicator + " " + resultobj.test_long_stdstream_string)
+                print(
+                    self.fail_long_indicator
+                    + " "
+                    + resultobj.test_long_stdstream_string
+                )
                 print(" ")  # add newline to stdout before exiting
                 sys.exit(1)
         elif resultobj.test_failed is False:
@@ -45,7 +51,9 @@ class StdStreamer(object):
     def stream_final_failures(self, result_list):
         if len(result_list) > 0:
             print(" ")
-            fail_string = self.ufopath + " failed ufolint testing! Exit with status code 1"
+            fail_string = (
+                self.ufopath + " failed ufolint testing! Exit with status code 1"
+            )
             print(" ")
             print("=" * len(fail_string))
             print(fail_string)
@@ -56,7 +64,11 @@ class StdStreamer(object):
             result_list_deduped = OrderedDict((x, True) for x in result_list).keys()
 
             for resultobj in result_list_deduped:
-                print(self.fail_long_indicator + " " + resultobj.test_long_stdstream_string)
+                print(
+                    self.fail_long_indicator
+                    + " "
+                    + resultobj.test_long_stdstream_string
+                )
             sys.exit(1)
         else:
             success_string = self.ufopath + " - All ufolint tests passed!"

--- a/lib/ufolint/utilities/__init__.py
+++ b/lib/ufolint/utilities/__init__.py
@@ -6,7 +6,9 @@ import os
 
 def dir_exists(dirpath):
     """Tests for existence of a directory on the string filepath"""
-    if os.path.exists(dirpath) and os.path.isdir(dirpath):  # test that exists and is a directory
+    if os.path.exists(dirpath) and os.path.isdir(
+        dirpath
+    ):  # test that exists and is a directory
         return True
     else:
         return False
@@ -14,7 +16,9 @@ def dir_exists(dirpath):
 
 def file_exists(filepath):
     """Tests for existence of a file on the string filepath"""
-    if os.path.exists(filepath) and os.path.isfile(filepath):  # test that exists and is a file
+    if os.path.exists(filepath) and os.path.isfile(
+        filepath
+    ):  # test that exists and is a file
         return True
     else:
         return False

--- a/lib/ufolint/validators/glifvalidators.py
+++ b/lib/ufolint/validators/glifvalidators.py
@@ -14,6 +14,7 @@ class GlifObj(object):
     """
     A simple object for use in ufoLib attribute assignments for *.glif file testing.
     """
+
     def __init__(self):
         pass
 
@@ -23,34 +24,51 @@ def run_all_glif_validations(ufoobj):
     ufoversion = ufoobj.get_ufo_version()
     ss = StdStreamer(ufoobj.ufopath)
     test_error_list = []
-    for glyphsdir in glyphsdir_path_list:  # for each directory that containts .glif files
+    for (
+        glyphsdir
+    ) in glyphsdir_path_list:  # for each directory that containts .glif files
         print(" ")
         sys.stdout.write(" - " + glyphsdir + "  ")
         sys.stdout.flush()
         res = Result(glyphsdir)
         try:
-            gs = GlyphSet(glyphsdir, ufoFormatVersion=ufoversion, validateRead=True)   # create a ufoLib GlyphSet
+            gs = GlyphSet(
+                glyphsdir, ufoFormatVersion=ufoversion, validateRead=True
+            )  # create a ufoLib GlyphSet
             # do not report success for this, previous testing has passed this
         except Exception as e:
             res.test_failed = True
-            res.test_long_stdstream_string = " Failed to read glif file paths from " + glyphsdir + ". Error: " + str(e)
+            res.test_long_stdstream_string = (
+                " Failed to read glif file paths from "
+                + glyphsdir
+                + ". Error: "
+                + str(e)
+            )
             ss.stream_result(res)
             test_error_list.append(res)
             break  # break out loop as it was not possible to read the GlyphSet for this directory, gs not instantiated
 
         glif_count = 0  # reset glyphs directory .glif file counter
-        for glyphname in gs.contents.keys():    # for each .glif file (read from glyph name in glyph set contents dict)
+        for (
+            glyphname
+        ) in (
+            gs.contents.keys()
+        ):  # for each .glif file (read from glyph name in glyph set contents dict)
             res = Result(gs.contents[glyphname])
             try:
                 go = GlifObj()
-                gs.readGlyph(glyphname, glyphObject=go)   # read the glif file and perform ufoLib validations, requires the glyphObject for validations
+                gs.readGlyph(
+                    glyphname, glyphObject=go
+                )  # read the glif file and perform ufoLib validations, requires the glyphObject for validations
                 res.test_failed = False
                 ss.stream_result(res)
                 glif_count += 1
             except Exception as e:
                 res.test_failed = True
                 filename = os.path.join(glyphsdir, glyphNameToFileName(glyphname, None))
-                res.test_long_stdstream_string = '{} (glyph "{}"): Test failed with error: {}'.format(filename, glyphname, e)
+                res.test_long_stdstream_string = '{} (glyph "{}"): Test failed with error: {}'.format(
+                    filename, glyphname, e
+                )
                 ss.stream_result(res)
                 test_error_list.append(res)
                 glif_count += 1

--- a/lib/ufolint/validators/imagesvalidators.py
+++ b/lib/ufolint/validators/imagesvalidators.py
@@ -19,18 +19,24 @@ def run_all_images_validations(ufoobj):
     """
     test_error_list = []
     ss = StdStreamer(ufoobj.ufopath)
-    images_dir_path = os.path.join(ufoobj.ufopath, 'images')
+    images_dir_path = os.path.join(ufoobj.ufopath, "images")
 
     if dir_exists(images_dir_path) is False:
-        return []       # if the directory path does not exist, return an empty test_error_list to calling code
+        return (
+            []
+        )  # if the directory path does not exist, return an empty test_error_list to calling code
 
     for testimage_rel_path in os.listdir(images_dir_path):
         testimage_path = os.path.join(images_dir_path, testimage_rel_path)
         if file_exists(testimage_path):
-            if testimage_rel_path[0] == ".":   # ignore files that are dotfiles in directory (e.g. .DS_Store on OS X)
+            if (
+                testimage_rel_path[0] == "."
+            ):  # ignore files that are dotfiles in directory (e.g. .DS_Store on OS X)
                 pass
             else:
-                passed_ufolib_tests, error = pngValidator(path=testimage_path)   # call ufoLib PNG validator directly
+                passed_ufolib_tests, error = pngValidator(
+                    path=testimage_path
+                )  # call ufoLib PNG validator directly
                 res = Result(testimage_path)
 
                 if passed_ufolib_tests is True:
@@ -38,7 +44,11 @@ def run_all_images_validations(ufoobj):
                     ss.stream_result(res)
                 else:
                     res.test_failed = True
-                    res.test_long_stdstream_string = testimage_path + " failed with error: " + error
-                    test_error_list.append(res)    # add to error list returned to calling code
+                    res.test_long_stdstream_string = (
+                        testimage_path + " failed with error: " + error
+                    )
+                    test_error_list.append(
+                        res
+                    )  # add to error list returned to calling code
                     ss.stream_result(res)
-    return test_error_list   # return list of identified errors to the calling code
+    return test_error_list  # return list of identified errors to the calling code

--- a/lib/ufolint/validators/plistvalidators.py
+++ b/lib/ufolint/validators/plistvalidators.py
@@ -36,9 +36,13 @@ class AbstractPlistValidator(object):
             return res
         except Exception as e:
             res.test_failed = True
-            if testpath in self.mandatory_filepaths_list:  # if this test is on a mandatory file, exit early with fail
+            if (
+                testpath in self.mandatory_filepaths_list
+            ):  # if this test is on a mandatory file, exit early with fail
                 res.exit_failure = True
-            res.test_long_stdstream_string = testpath + " failed XML validation test with error: " + str(e)
+            res.test_long_stdstream_string = (
+                testpath + " failed XML validation test with error: " + str(e)
+            )
             self.test_fail_list.append(res)  # add each failure to test failures list
             return res
 
@@ -49,7 +53,7 @@ class AbstractPlistValidator(object):
             if file_exists(testpath):
                 res = self._parse_xml(testpath)
                 ss.stream_result(res)
-            else:     # there is no file to check, mandatory files have already been checked, this is a success
+            else:  # there is no file to check, mandatory files have already been checked, this is a success
                 res = Result(testpath)
                 res.test_failed = False
                 ss.stream_result(res)
@@ -63,7 +67,9 @@ class AbstractPlistValidator(object):
                     res = Result(testpath)
                     res.test_failed = False
                     ss.stream_result(res)
-        return self.test_fail_list  # return to the calling code so that it can be maintained for final user report
+        return (
+            self.test_fail_list
+        )  # return to the calling code so that it can be maintained for final user report
 
     def run_ufolib_import_validation(self):
         raise NotImplementedError
@@ -71,7 +77,9 @@ class AbstractPlistValidator(object):
 
 class MetainfoPlistValidator(AbstractPlistValidator):
     def __init__(self, ufopath, ufoversion, glyphs_dir_list):
-        super(MetainfoPlistValidator, self).__init__(ufopath, ufoversion, glyphs_dir_list)
+        super(MetainfoPlistValidator, self).__init__(
+            ufopath, ufoversion, glyphs_dir_list
+        )
         self.testfile = "metainfo.plist"
         self.testpath = self.ufoobj.get_root_plist_filepath(self.testfile)
 
@@ -84,10 +92,14 @@ class MetainfoPlistValidator(AbstractPlistValidator):
 
         res = Result(self.testpath)
         ss = StdStreamer(self.ufopath)
-        if file_exists(self.testpath) is False:  # fail test, exit early if file is missing
+        if (
+            file_exists(self.testpath) is False
+        ):  # fail test, exit early if file is missing
             res.test_failed = True
             res.exit_failure = True
-            res.test_long_stdstream_string = "metainfo.plist is not available on the path " + self.testpath
+            res.test_long_stdstream_string = (
+                "metainfo.plist is not available on the path " + self.testpath
+            )
             ss.stream_result(res)
         try:
             ufolib_reader = UFOReader(self.ufopath, validate=True)
@@ -97,7 +109,9 @@ class MetainfoPlistValidator(AbstractPlistValidator):
         except Exception as e:
             res.test_failed = True
             res.exit_failure = True
-            res.test_long_stdstream_string = self.testpath + " failed ufoLib import test with error: " + str(e)
+            res.test_long_stdstream_string = (
+                self.testpath + " failed ufoLib import test with error: " + str(e)
+            )
             self.test_fail_list.append(res)
             ss.stream_result(res)
         return self.test_fail_list
@@ -105,13 +119,16 @@ class MetainfoPlistValidator(AbstractPlistValidator):
 
 class FontinfoPlistValidator(AbstractPlistValidator):
     def __init__(self, ufopath, ufoversion, glyphs_dir_list):
-        super(FontinfoPlistValidator, self).__init__(ufopath, ufoversion, glyphs_dir_list)
+        super(FontinfoPlistValidator, self).__init__(
+            ufopath, ufoversion, glyphs_dir_list
+        )
         self.testfile = "fontinfo.plist"
         self.testpath = self.ufoobj.get_root_plist_filepath(self.testfile)
 
         class FontInfoObj(object):
             def __init__(self):
                 pass
+
         self.fontinfo_obj = FontInfoObj()
 
     def run_ufolib_import_validation(self):
@@ -122,7 +139,9 @@ class FontinfoPlistValidator(AbstractPlistValidator):
         res = Result(self.testpath)
         ss = StdStreamer(self.ufopath)
         if file_exists(self.testpath) is False:
-            res.test_failed = False     # not a mandatory file in UFO spec, test passes if missing
+            res.test_failed = (
+                False
+            )  # not a mandatory file in UFO spec, test passes if missing
             ss.stream_result(res)
             return self.test_fail_list
         try:
@@ -133,7 +152,9 @@ class FontinfoPlistValidator(AbstractPlistValidator):
             ss.stream_result(res)
         except Exception as e:
             res.test_failed = True
-            res.test_long_stdstream_string = self.testpath + " failed ufoLib import test with error: " + str(e)
+            res.test_long_stdstream_string = (
+                self.testpath + " failed ufoLib import test with error: " + str(e)
+            )
             ss.stream_result(res)
             self.test_fail_list.append(res)
         return self.test_fail_list
@@ -153,7 +174,9 @@ class GroupsPlistValidator(AbstractPlistValidator):
         res = Result(self.testpath)
         ss = StdStreamer(self.ufopath)
         if file_exists(self.testpath) is False:
-            res.test_failed = False     # not a mandatory file in UFO spec, test passes if missing
+            res.test_failed = (
+                False
+            )  # not a mandatory file in UFO spec, test passes if missing
             ss.stream_result(res)
             return self.test_fail_list
         try:
@@ -164,7 +187,9 @@ class GroupsPlistValidator(AbstractPlistValidator):
             ss.stream_result(res)
         except Exception as e:
             res.test_failed = True
-            res.test_long_stdstream_string = self.testpath + " failed ufoLib import test with error: " + str(e)
+            res.test_long_stdstream_string = (
+                self.testpath + " failed ufoLib import test with error: " + str(e)
+            )
             ss.stream_result(res)
             self.test_fail_list.append(res)
         return self.test_fail_list
@@ -172,7 +197,9 @@ class GroupsPlistValidator(AbstractPlistValidator):
 
 class KerningPlistValidator(AbstractPlistValidator):
     def __init__(self, ufopath, ufoversion, glyphs_dir_list):
-        super(KerningPlistValidator, self).__init__(ufopath, ufoversion, glyphs_dir_list)
+        super(KerningPlistValidator, self).__init__(
+            ufopath, ufoversion, glyphs_dir_list
+        )
         self.testfile = "kerning.plist"
         self.testpath = self.ufoobj.get_root_plist_filepath(self.testfile)
 
@@ -184,7 +211,9 @@ class KerningPlistValidator(AbstractPlistValidator):
         res = Result(self.testpath)
         ss = StdStreamer(self.ufopath)
         if file_exists(self.testpath) is False:
-            res.test_failed = False     # not a mandatory file in UFO spec, test passes if missing
+            res.test_failed = (
+                False
+            )  # not a mandatory file in UFO spec, test passes if missing
             ss.stream_result(res)
             return self.test_fail_list
         try:
@@ -195,7 +224,9 @@ class KerningPlistValidator(AbstractPlistValidator):
             ss.stream_result(res)
         except Exception as e:
             res.test_failed = True
-            res.test_long_stdstream_string = self.testpath + " failed ufoLib import test with error: " + str(e)
+            res.test_long_stdstream_string = (
+                self.testpath + " failed ufoLib import test with error: " + str(e)
+            )
             ss.stream_result(res)
             self.test_fail_list.append(res)
         return self.test_fail_list
@@ -215,7 +246,9 @@ class LibPlistValidator(AbstractPlistValidator):
         res = Result(self.testpath)
         ss = StdStreamer(self.ufopath)
         if file_exists(self.testpath) is False:
-            res.test_failed = False     # not a mandatory file in UFO spec, test passes if missing
+            res.test_failed = (
+                False
+            )  # not a mandatory file in UFO spec, test passes if missing
             ss.stream_result(res)
             return self.test_fail_list
         try:
@@ -226,7 +259,9 @@ class LibPlistValidator(AbstractPlistValidator):
             ss.stream_result(res)
         except Exception as e:
             res.test_failed = True
-            res.test_long_stdstream_string = self.testpath + " failed ufoLib import test with error: " + str(e)
+            res.test_long_stdstream_string = (
+                self.testpath + " failed ufoLib import test with error: " + str(e)
+            )
             ss.stream_result(res)
             self.test_fail_list.append(res)
         return self.test_fail_list
@@ -234,8 +269,12 @@ class LibPlistValidator(AbstractPlistValidator):
 
 class ContentsPlistValidator(AbstractPlistValidator):
     def __init__(self, ufopath, ufoversion, glyphs_dir_list):
-        super(ContentsPlistValidator, self).__init__(ufopath, ufoversion, glyphs_dir_list)
-        self.testfile = "contents.plist"  # can occur in multiple glyphs directories in UFOv3+
+        super(ContentsPlistValidator, self).__init__(
+            ufopath, ufoversion, glyphs_dir_list
+        )
+        self.testfile = (
+            "contents.plist"
+        )  # can occur in multiple glyphs directories in UFOv3+
         self.glyphs_dir_list = glyphs_dir_list
 
     def run_ufolib_import_validation(self):
@@ -251,13 +290,20 @@ class ContentsPlistValidator(AbstractPlistValidator):
                 # read contents.plist with ufoLib as GlyphSet instantiation
                 # the ufoLib library performs type validations on values on read
                 # glyphs_dir_list is a list of lists mapped to glyphs dir name, glyphs dir path
-                GlyphSet(rel_dir_path, ufoFormatVersion=self.ufoversion, validateRead=True)  # test for raised exceptions
+                GlyphSet(
+                    rel_dir_path, ufoFormatVersion=self.ufoversion, validateRead=True
+                )  # test for raised exceptions
                 res.test_failed = False
                 ss.stream_result(res)
             except Exception as e:
                 res.test_failed = True
                 res.exit_failure = True  # mandatory file
-                res.test_long_stdstream_string = "contents.plist in " + rel_dir_path + " failed ufoLib import test with error: " + str(e)
+                res.test_long_stdstream_string = (
+                    "contents.plist in "
+                    + rel_dir_path
+                    + " failed ufoLib import test with error: "
+                    + str(e)
+                )
                 self.test_fail_list.append(res)
                 ss.stream_result(res)
         return self.test_fail_list
@@ -265,7 +311,9 @@ class ContentsPlistValidator(AbstractPlistValidator):
 
 class LayercontentsPlistValidator(AbstractPlistValidator):
     def __init__(self, ufopath, ufoversion, glyphs_dir_list):
-        super(LayercontentsPlistValidator, self).__init__(ufopath, ufoversion, glyphs_dir_list)
+        super(LayercontentsPlistValidator, self).__init__(
+            ufopath, ufoversion, glyphs_dir_list
+        )
         self.testfile = "layercontents.plist"
         self.testpath = self.ufoobj.get_root_plist_filepath(self.testfile)
 
@@ -276,7 +324,9 @@ class LayercontentsPlistValidator(AbstractPlistValidator):
         """
         res = Result(self.testpath)
         ss = StdStreamer(self.ufopath)
-        if file_exists(self.testpath) is False:   # should only meet this condition if not a mandatory file (runner.py checks)
+        if (
+            file_exists(self.testpath) is False
+        ):  # should only meet this condition if not a mandatory file (runner.py checks)
             res.test_failed = False
             ss.stream_result(res)
             return self.test_fail_list
@@ -287,12 +337,18 @@ class LayercontentsPlistValidator(AbstractPlistValidator):
             res.test_failed = False
             ss.stream_result(res)
         except Exception as e:
-            if self.testpath in self.mandatory_filepaths_list:  # if part of mandatory file spec for UFO version, fail early
+            if (
+                self.testpath in self.mandatory_filepaths_list
+            ):  # if part of mandatory file spec for UFO version, fail early
                 res.test_failed = True
-                res.exit_failure = True   # fail early b/c it is mandatory part of spec
+                res.exit_failure = True  # fail early b/c it is mandatory part of spec
             else:
-                res.test_failed = True    # fail the test, but wait to report until all other tests complete
-            res.test_long_stdstream_string = self.testpath + " failed ufoLib import test with error: " + str(e)
+                res.test_failed = (
+                    True
+                )  # fail the test, but wait to report until all other tests complete
+            res.test_long_stdstream_string = (
+                self.testpath + " failed ufoLib import test with error: " + str(e)
+            )
             self.test_fail_list.append(res)
             ss.stream_result(res)
         return self.test_fail_list
@@ -300,12 +356,15 @@ class LayercontentsPlistValidator(AbstractPlistValidator):
 
 class LayerinfoPlistValidator(AbstractPlistValidator):
     def __init__(self, ufopath, ufoversion, glyphs_dir_list):
-        super(LayerinfoPlistValidator, self).__init__(ufopath, ufoversion, glyphs_dir_list)
+        super(LayerinfoPlistValidator, self).__init__(
+            ufopath, ufoversion, glyphs_dir_list
+        )
         self.testfile = "layerinfo.plist"
 
         class LayerInfoObj(object):
             def __init__(self):
                 pass
+
         self.layerinfo_obj = LayerInfoObj()
 
     def run_ufolib_import_validation(self):
@@ -319,13 +378,20 @@ class LayerinfoPlistValidator(AbstractPlistValidator):
             rel_dir_path = os.path.join(self.ufopath, glyphs_dir[1])
 
             try:
-                gs = GlyphSet(rel_dir_path, ufoFormatVersion=self.ufoversion, validateRead=True)
+                gs = GlyphSet(
+                    rel_dir_path, ufoFormatVersion=self.ufoversion, validateRead=True
+                )
                 gs.readLayerInfo(self.layerinfo_obj)
                 res.test_failed = False
                 ss.stream_result(res)
             except Exception as e:
                 res.test_failed = True
-                res.test_long_stdstream_string = "layerinfo.plist in " + rel_dir_path + " failed ufoLib import test with error: " + str(e)
+                res.test_long_stdstream_string = (
+                    "layerinfo.plist in "
+                    + rel_dir_path
+                    + " failed ufoLib import test with error: "
+                    + str(e)
+                )
                 self.test_fail_list.append(res)
                 ss.stream_result(res)
         return self.test_fail_list

--- a/lib/ufolint/validators/plistvalidators.py
+++ b/lib/ufolint/validators/plistvalidators.py
@@ -2,11 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os.path
-
-try:  # pragma: no cover
-    import xml.etree.cElementTree as ETree
-except ImportError:   # pragma: no cover
-    import xml.etree.ElementTree as ETree
+import xml.etree.ElementTree as ETree
 
 from ufolint.data.tstobj import Result
 from ufolint.data.ufo import Ufo2, Ufo3

--- a/lib/ufolint/validators/typevalidators.py
+++ b/lib/ufolint/validators/typevalidators.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-try:  # pragma: no cover
-    basestring
-except NameError:  # pragma: no cover
-    basestring = str
-
 
 def is_string_type(needle):
-    if isinstance(needle, basestring):
+    if isinstance(needle, str):
         return True
     else:
         return False

--- a/lib/ufolint/validators/xmlvalidators.py
+++ b/lib/ufolint/validators/xmlvalidators.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import xml.etree.ElementTree as Etree             # python 3
+import xml.etree.ElementTree as Etree  # python 3
 
 
 def is_valid_xml_path(filepath):

--- a/lib/ufolint/validators/xmlvalidators.py
+++ b/lib/ufolint/validators/xmlvalidators.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-try:  # pragma: no cover
-    import xml.etree.cElementTree as Etree            # python 2
-except ImportError:  # pragma: no cover
-    import xml.etree.ElementTree as Etree             # python 3
+import xml.etree.ElementTree as Etree             # python 3
 
 
 def is_valid_xml_path(filepath):

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-python3 setup.py sdist bdist_wheel
-#twine upload dist/ufolint-0.1.0*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-fontTools==3.44.0
+fontTools[ufo]==3.44.0
 commandlines

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-fontTools[ufo]==3.44.0
+fontTools[ufo]==4.0.0
 commandlines

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,16 @@
+import io
 import os
 import re
+import sys
 from setuptools import setup, find_packages
 
+REQUIRES_PYTHON = ">=3.5.0"
 
-def docs_read(fname):
-    return open(os.path.join(os.path.dirname(__file__), 'docs', fname)).read()
+# Optional packages
+EXTRAS_REQUIRES = {
+    # for developer installs
+    "dev": ["wheel", "setuptools", "twine", "coverage", "pytest", "tox", "flake8", "pytype"]
+}
 
 
 def version_read():
@@ -27,11 +33,24 @@ def version_read():
     return major_version + "." + minor_version + "." + patch_version
 
 
+# Use repository Markdown README.md for PyPI long description
+try:
+    with io.open("README.md", encoding="utf-8") as f:
+        readme = f.read()
+except IOError as readme_e:
+    sys.stderr.write(
+        "[ERROR] setup.py: Failed to read the README.md file for the long description definition: {}".format(
+            str(readme_e)
+        )
+    )
+    raise readme_e
+
 setup(
     name='ufolint',
     version=version_read(),
     description='UFO source file linter',
-    long_description=(docs_read('README.rst')),
+    long_description=readme,
+    long_description_content_type="text/markdown",
     url='https://github.com/source-foundry/ufolint',
     license='MIT license',
     author='Christopher Simpkins',
@@ -44,9 +63,11 @@ setup(
         'console_scripts': [
             'ufolint = ufolint.app:main'
         ],
-},
+    },
     keywords='',
     include_package_data=True,
+    extras_require=EXTRAS_REQUIRES,
+    python_requires=REQUIRES_PYTHON,
     classifiers=[
         'Development Status :: 4 - Beta',
         'Natural Language :: English',
@@ -59,6 +80,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Topic :: Software Development :: Libraries :: Python Modules'
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        "Topic :: Text Processing :: Fonts",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import re
 import sys
 from setuptools import setup, find_packages
 
-REQUIRES_PYTHON = ">=3.5.0"
+REQUIRES_PYTHON = ">=3.6.0"
 
 # Optional packages
 EXTRAS_REQUIRES = {
@@ -15,9 +15,9 @@ EXTRAS_REQUIRES = {
 
 def version_read():
     settings_file = open(os.path.join(os.path.dirname(__file__), 'lib', 'ufolint', 'settings.py')).read()
-    major_regex = """major_version\s*?=\s*?["']{1}(\d+)["']{1}"""
-    minor_regex = """minor_version\s*?=\s*?["']{1}(\d+)["']{1}"""
-    patch_regex = """patch_version\s*?=\s*?["']{1}(\d+)["']{1}"""
+    major_regex = r"""major_version\s*?=\s*?["']{1}(\d+)["']{1}"""
+    minor_regex = r"""minor_version\s*?=\s*?["']{1}(\d+)["']{1}"""
+    patch_regex = r"""patch_version\s*?=\s*?["']{1}(\d+)["']{1}"""
     major_match = re.search(major_regex, settings_file)
     minor_match = re.search(minor_regex, settings_file)
     patch_match = re.search(patch_regex, settings_file)
@@ -74,12 +74,9 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
         "Topic :: Text Processing :: Fonts",
     ],

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-# test_runner.sh : local testing script
-
-tox -e py27,py37

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,11 @@
 [tox]
-envlist = py27, py35, py36, py37
+envlist = py37
 
 [testenv]
-passenv = TOXENV CI TRAVIS TRAVIS_*
 commands =
-    py.test tests
-
+    py.test
 deps =
     pytest
     pytest-mock
     mock
     coverage
-    codecov>=1.4.0
-
-
-;[testenv:cov-report]
-;commands = py.test --cov=ufolint --cov-report=term --cov-report=html


### PR DESCRIPTION
This PR removes support for Python 2.7 and defines the support level at Python 3.6+

The changes include:

- converted from `ufoLib` to `fontTools.ufoLib` dependency
- dropped support for Python 2.7
- dropped support for Python 3 versions < 3.6
- setup.py overhaul with new Python 3.6+ Python interpreter requirement
- add fontTools [ufo] extras dependencies to requirements.txt
- switched Py2 `basestring` type to `str` type in `ufolint.validators.typevalidators` module
- removed Py2 `plistlib.readPlist` in `ufolint.controllers.runner` module
- removed Py2 `xml.etree.CElementTree` in `ufolint.validators.plistvalidators`
- removed Py2 `xml.etree.CElementTree` in `ufolint.validators.xmlvalidators`
- PEP8 formatting changes
- add `Makefile`
- remove unnecessary shell scripts (functionality replaced by Makefile)
- update `MANIFEST.in` file paths
- changed Python interpreter version in `tox.ini` configuration file

There are no changes to the API or application functionality in this PR.