### PR TITLE
Update Travis macOS testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
     - os: osx
       language: generic
       osx_image: xcode11    # Python 3.7.4 running on macOS 10.14.4
-      install: pip install --upgrade tox pytest
+      install: pip3 install --upgrade tox pytest
       env: TOX_ENV=py37
       script: tox -e $TOX_ENV
 


### PR DESCRIPTION
Builds failing on macOS only.  Looks like this is a py3 associated error because pip is the Py2 version?  Attempting to fix with explicit call to `pip3` for dependencies