### PR TITLE
Add GH Actions pull request trigger support

### DIFF
--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -1,6 +1,6 @@
 name: Python CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/py-coverage.yml
+++ b/.github/workflows/py-coverage.yml
@@ -1,6 +1,6 @@
 name: Coverage
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -1,6 +1,6 @@
 name: Python Lints
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
The current configuration only runs unit test/coverage/source lints on branch pushes.  This adds PR triggers for source that originates in a forked repository.