### PR TITLE
Fix bug where path needed to be string

### DIFF
--- a/lib/ufolint/validators/plistvalidators.py
+++ b/lib/ufolint/validators/plistvalidators.py
@@ -289,7 +289,7 @@ class ContentsPlistValidator(AbstractPlistValidator):
                 # glyphs_dir_list is a list of lists mapped to glyphs dir name,
                 # glyphs dir path
                 gs = GlyphSet(
-                    rel_dir_path, ufoFormatVersion=self.ufoversion, validateRead=True
+                    str(rel_dir_path), ufoFormatVersion=self.ufoversion, validateRead=True
                 )  # test for raised exceptions
                 res.test_failed = False
 


### PR DESCRIPTION
`[FAIL] contents.plist in font.ufo/glyphs failed ufoLib import test with error: Expected a path string or fs object, found PosixPath` - Occurring because ufolib sometimes expects a string instead of a path object. We don't know why, but it causes an error in some python installations.