### PR TITLE
Contents.plist: use right exception when missing

### DIFF
--- a/lib/ufolint/validators/plistvalidators.py
+++ b/lib/ufolint/validators/plistvalidators.py
@@ -289,29 +289,29 @@ class ContentsPlistValidator(AbstractPlistValidator):
                 # glyphs_dir_list is a list of lists mapped to glyphs dir name,
                 # glyphs dir path
                 gs = GlyphSet(
-                    str(rel_dir_path), ufoFormatVersion=self.ufoversion, validateRead=True
+                    str(rel_dir_path),
+                    ufoFormatVersion=self.ufoversion,
+                    validateRead=True,
+                    expectContentsFile=True,
                 )  # test for raised exceptions
                 res.test_failed = False
 
-                # Check for unlisted files if contents.plist exists. It is mandated by
-                # the spec, but if it does not exist, glifLib will shrug and say the
-                # glyph set was empty.
-                if (rel_dir_path / self.testfile).exists():
-                    files = set(gs.contents.values())
-                    files.update(("contents.plist", "layerinfo.plist"))
-                    files_actually = set(
-                        str(p.relative_to(rel_dir_path))
-                        for p in rel_dir_path.glob("**/*")
+                # Check for unlisted files.
+                files = set(gs.contents.values())
+                files.update(("contents.plist", "layerinfo.plist"))
+                files_actually = set(
+                    str(p.relative_to(rel_dir_path))
+                    for p in rel_dir_path.glob("**/*")
+                )
+                unlisted_files = files_actually - files
+                if unlisted_files:
+                    res.test_failed = True
+                    res.exit_failure = True  # sacrilege
+                    res.test_long_stdstream_string = (
+                        f"{str(rel_dir_path)} contains rogue files not listed "
+                        f"in contents.plist: {', '.join(unlisted_files)}"
                     )
-                    unlisted_files = files_actually - files
-                    if unlisted_files:
-                        res.test_failed = True
-                        res.exit_failure = True  # sacrilege
-                        res.test_long_stdstream_string = (
-                            f"{str(rel_dir_path)} contains rogue files not listed "
-                            f"in contents.plist: {', '.join(unlisted_files)}"
-                        )
-                        self.test_fail_list.append(res)
+                    self.test_fail_list.append(res)
 
                 ss.stream_result(res)
             except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 appdirs==1.4.4            # via fs
 commandlines==0.4.1       # via ufolint (setup.py)
-fonttools[ufo]==4.17.1    # via ufolint (setup.py)
+fonttools[ufo]==4.18.0    # via ufolint (setup.py)
 fs==2.4.11                # via fonttools
 pytz==2020.4              # via fs
 six==1.15.0               # via fs

--- a/tests/test_validator_plist.py
+++ b/tests/test_validator_plist.py
@@ -621,30 +621,38 @@ def test_validators_plist_ufo3_contents_success():
 
 # Fail tests
 
-def test_validators_plist_ufo2_contents_missing_file_fail():
+def test_validators_plist_ufo2_contents_missing_file_fail(capsys):
     contents_ufo_path = os.path.join(contents_test_dir_failpath, 'UFO2-MissingCont.ufo')
     contents_validator = plistvalidators.ContentsPlistValidator(contents_ufo_path, 2, ufo2_dir_list)
 
     xml_fail_list = contents_validator.run_xml_validation()
-    ufolib_fail_list = contents_validator.run_ufolib_import_validation()
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        contents_validator.run_ufolib_import_validation()
 
     assert isinstance(xml_fail_list, list)
-    assert isinstance(ufolib_fail_list, list)
-    assert len(xml_fail_list) == 0
-    assert len(ufolib_fail_list) == 0
+    assert len(xml_fail_list) == 1
+
+    out, _ = capsys.readouterr()
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 1
+    assert 'contents.plist is missing.' in out
 
 
-def test_validators_plist_ufo3_contents_missing_file_fail():
+def test_validators_plist_ufo3_contents_missing_file_fail(capsys):
     contents_ufo_path = os.path.join(contents_test_dir_failpath, 'UFO3-MissingCont.ufo')
     contents_validator = plistvalidators.ContentsPlistValidator(contents_ufo_path, 3, ufo3_dir_list)
 
     xml_fail_list = contents_validator.run_xml_validation()
-    ufolib_fail_list = contents_validator.run_ufolib_import_validation()
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        contents_validator.run_ufolib_import_validation()
 
     assert isinstance(xml_fail_list, list)
-    assert isinstance(ufolib_fail_list, list)
-    assert len(xml_fail_list) == 0
-    assert len(ufolib_fail_list) == 0
+    assert len(xml_fail_list) == 1
+
+    out, _ = capsys.readouterr()
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 1
+    assert 'contents.plist is missing.' in out
 
 
 def test_validators_plist_ufo3_contents_missing_file_fail(capsys):


### PR DESCRIPTION
Need to figure out the tests. `test_validators_plist_ufo2_contents_missing_file_fail` and `test_validators_plist_ufo3_contents_missing_file_fail` don't actually test for failure?