### PR TITLE
Refactor deprecated fontTools.ufoLib.UFOReader property

### DIFF
--- a/lib/ufolint/controllers/runner.py
+++ b/lib/ufolint/controllers/runner.py
@@ -353,7 +353,7 @@ class MainRunner(object):
         res = Result(self.ufopath)
         try:
             ufolib_reader = UFOReader(self.ufopath, validate=True)
-            self.ufoversion = ufolib_reader.formatVersion
+            self.ufoversion = ufolib_reader.formatVersionTuple[0]
             self.ufolib_reader = ufolib_reader
             res.test_failed = False
             ss.stream_result(res)


### PR DESCRIPTION
Fixes #88

The UFO source format version property on the ufoLib.UFOReader class that we use here is now deprecated. This PR changes our references to the new property that has been defined.